### PR TITLE
fix: add config for base path

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,4 +4,5 @@ import { defineConfig } from "astro/config";
 // https://astro.build/config
 export default defineConfig({
   site: "https://fivh-bergen.github.io",
+  base: "/kart",
 });


### PR DESCRIPTION
This might be needed for github pages, according to [the docs](https://docs.astro.build/en/guides/deploy/github/)