### PR TITLE
feat: deploy page after  fetching new data

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,7 @@ on:
     branches: [main]
   # Allows you to run this workflow manually from the Actions tab on GitHub.
   workflow_dispatch:
+  workflow_call:
 
 # Allow this job to clone the repo and create a page deployment
 permissions:

--- a/.github/workflows/fetch-features.yml
+++ b/.github/workflows/fetch-features.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Fetch data from features, and save it to src/pages/features.json
         run: curl https://overpass-api.de/api/interpreter\?data\=%5Bout%3Ajson%5D%5Btimeout%3A25%5D%3Barea%283600404159%29%2D%3E%2EsearchArea%3Bnwr%5B%22shop%22%3D%22second%5Fhand%22%5D%28area%2EsearchArea%29%3Bout%20geom%3B%0A > src/pages/features.json
@@ -27,3 +28,5 @@ jobs:
         with:
           commit_message: "chore: update features.json"
           commit_options: "--no-verify"
+  deploy:
+    uses: fivh-bergen/kart/.github/workflows/deploy.yml@main


### PR DESCRIPTION
This change will make it so that the page will automatically be deployed to github pages after we have retrieved the most recent JSON data