### PR TITLE
fix: apply correct permissions to called workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,8 +5,6 @@ on:
   # Using a different branch name? Replace `main` with your branch’s name
   push:
     branches: [main]
-  # Allows you to run this workflow manually from the Actions tab on GitHub.
-  workflow_dispatch:
   workflow_call:
 
 # Allow this job to clone the repo and create a page deployment

--- a/.github/workflows/fetch-features.yml
+++ b/.github/workflows/fetch-features.yml
@@ -32,4 +32,5 @@ jobs:
     permissions:
       pages: write
       id-token: write
+      contents: read
     uses: fivh-bergen/kart/.github/workflows/deploy.yml@main


### PR DESCRIPTION
also remove unnecessary dispatch option on deploy workflow. End users may find the dispatch button for the deploy workflow misleading, since it is the "fetch data" workflow that actually updates the OSM data. The deploy dispatch doesn't really do anything special. 