### PR TITLE
fix: install dependencies in fetch-features workflow

### DIFF
--- a/.github/workflows/fetch-features.yml
+++ b/.github/workflows/fetch-features.yml
@@ -31,6 +31,9 @@ jobs:
           node-version: 23
           cache: "pnpm"
 
+      - name: Install dependencies
+        run: pnpm install
+
       - name: Fetch nodes from Overpass API
         run: pnpm fetch-nodes
 


### PR DESCRIPTION
This should fix the workflows that aren't running due to a missing dependency (osmtogeojson)