### PR TITLE
fix: tweak marker positioning

### DIFF
--- a/src/components/marker.js
+++ b/src/components/marker.js
@@ -1,16 +1,23 @@
-import { renderToStaticMarkup } from "react-dom/server";
-
 /** Creates a marker element that can be added to a maplibre-gl map  */
 export function makeMarkerElement(featureName, className) {
   const element = document.createElement("div");
-  element.className = "marker";
+  element.className = "marker " + className;
+
+  // This grid
+  const grid = document.createElement("div");
+  grid.className = "marker-grid";
+
+  element.appendChild(grid);
 
   const flex = document.createElement("div");
   flex.className = "marker-flex";
 
-  element.appendChild(flex);
+  grid.appendChild(document.createElement("div"));
+
+  grid.appendChild(flex);
 
   const svg = document.createElement("div");
+  svg.className = "marker-pin";
 
   svg.innerHTML = markerSvg;
   flex.appendChild(svg);

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -52,8 +52,12 @@ import Layout from "../layouts/Layout.astro";
 
         const element = marker.getElement();
 
+        const pin = element.querySelector(".marker-pin");
+        if (!pin) {
+          throw new Error("No pin found in marker element");
+        }
         // add click event to open the info panel and pan camera if necessary
-        element.addEventListener("click", () => {
+        pin.addEventListener("click", () => {
           // Pan the camera so the marker is not behind the panel
 
           panMapToShowMarker(
@@ -64,7 +68,6 @@ import Layout from "../layouts/Layout.astro";
           setFeature(feature);
           showInfoPanel();
         });
-        element.style.cursor = "pointer";
       });
     }
   });
@@ -76,12 +79,16 @@ import Layout from "../layouts/Layout.astro";
     --display-second-hand: block;
     --display-rental: block;
   }
+  .marker-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+  }
 
   .marker-flex {
     display: flex;
-    flex-direction: row;
     align-items: center;
     gap: 0.4rem;
+    left: 50%;
   }
 
   .marker-label {
@@ -90,6 +97,11 @@ import Layout from "../layouts/Layout.astro";
 
   .marker-repair {
     display: var(--display-repair);
+  }
+
+  .marker-pin {
+    cursor: pointer;
+    margin-left: -13.5px;
   }
   .marker-second-hand {
     display: var(--display-second-hand);


### PR DESCRIPTION
Here we are adding a grid whose purpose is to split the marker elemtn in two equally wide halves. This is done because maplibre centers the marker in the map so that the middle of the element represents the location of the marker in the map. Without this tweak, the actual pin (the svg element) would appear far to the left of the actual geographical location of the point of interest (the middle of the element being somewhere in the middle-ish of the text label).

With this change, the center of the grid element is always at the start of the div where the pin and the label exist. We add a negative margin to the pin equal to half its width so that the pin point will be on the center. Without this markin, the left edge of the pin would meet the centre

![Screenshot 2025-02-21 at 18 48 37](https://github.com/user-attachments/assets/2aa63e3f-f4d7-4c7f-bcd8-0791e814da12)


Moving the click handler and cursor:pointer style to the pin ensure that the experience is nice for the user (otherwise we would have a large "invisible" area that would listen for the click.