### PR TITLE
fix: revert irrelevant change to query

### DIFF
--- a/src/overpass/queries/rental.overpassql
+++ b/src/overpass/queries/rental.overpassql
@@ -17,7 +17,6 @@ area(id:3600404159)->.searchArea;
   node["shop"="tool_hire"](area.searchArea);
   node["amenity"="tool_library"](area.searchArea);
   node["amenity"="toy_library"](area.searchArea);
-  node["shop"="rental"](area.searchArea);
 )->.rental;
 
 // find city bike docking stations


### PR DESCRIPTION
We already had this in the query, it turns out