### PR TITLE
feat: add badge in corner which opens panel with info about the service

### DIFF
--- a/src/components/InfoBadge.astro
+++ b/src/components/InfoBadge.astro
@@ -1,0 +1,26 @@
+<div id="info-badge" class="info-badge">?</div>
+
+<script>
+  import { clearFeature, showInfoPanel } from "../store/feature";
+  const badge = document.getElementById("info-badge");
+  if (badge) {
+    badge.addEventListener("click", () => {
+      clearFeature();
+      showInfoPanel();
+    });
+  }
+</script>
+
+<style>
+  .info-badge {
+    position: fixed;
+    font-weight: bold;
+    top: 0.3rem;
+    right: 0.3rem;
+    background-color: white;
+    border-radius: 0.5rem;
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+    cursor: pointer;
+    padding: 0.5rem;
+  }
+</style>

--- a/src/components/Panel.css
+++ b/src/components/Panel.css
@@ -5,7 +5,7 @@
   bottom: 0.3rem;
   width: 25%;
   background-color: white;
-  border-radius: 1rem;
+  border-radius: 0.5rem;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
   h1,
   h2,

--- a/src/components/Panel.tsx
+++ b/src/components/Panel.tsx
@@ -1,68 +1,115 @@
 import { useStore } from "@nanostores/react";
-import { $feature, $showInfoPanel, hideInfoPanel } from "../store/feature";
-import { OpeningHours } from "./OpeningHours";
-import { formatAddress } from "../utils/format-address";
-import KindBadge from "./KindBadge";
+import {
+  $feature,
+  $showInfoPanel,
+  hideInfoPanel,
+  type Feature,
+} from "../store/feature";
 import "./Panel.css";
+import type { PropsWithChildren } from "react";
+import { formatAddress } from "../utils/format-address";
 import { makeRapidURL } from "../utils/make-rapid-url";
+import KindBadge from "./KindBadge";
+import { OpeningHours } from "./OpeningHours";
 
 export const Panel = () => {
   const show = useStore($showInfoPanel);
 
   const feature = useStore($feature);
 
-  if (!show || !feature) {
-    return null;
-  } else {
-    const address = formatAddress(feature.address);
+  if (show && !feature) {
     return (
-      <div id="panel" className="panel">
-        <div id="panel-content" className="panel-content">
-          <button
-            id="panel-close"
-            className="close-button"
-            aria-label="Lukk"
-            onClick={hideInfoPanel}
-          >
-            &times;
-          </button>
-
-          <h1 id="feature-name">{feature.name}</h1>
-
-          <div className="panel-body">
-            <KindBadge kind={feature.kind} />
-
-            {address && <div> {address} </div>}
-            {feature.description && (
-              <p id="feature-description">{feature.description}</p>
-            )}
-
-            {feature?.opening_hours && (
-              <OpeningHours openingHours={feature.opening_hours} />
-            )}
-
-            {feature.website && (
-              <a href={feature.website} target="_blank">
-                Nettside
-              </a>
-            )}
-            {feature.facebook && (
-              <a href={feature.facebook} target="_blank">
-                Facebook
-              </a>
-            )}
-
-            <a
-              className="edit-link"
-              href={makeRapidURL(feature.long, feature.lat, feature.id)}
-              target="_blank"
-              rel="noreferrer"
-            >
-              Oppdater informasjon
-            </a>
-          </div>
-        </div>
-      </div>
+      <InfoPanel onClose={hideInfoPanel} title="Om tjenesten">
+        <ServiceInfo />
+      </InfoPanel>
     );
+  } else if (show && feature) {
+    return (
+      <InfoPanel onClose={hideInfoPanel} title={feature.name}>
+        <FeatureInfo feature={feature} />
+      </InfoPanel>
+    );
+  } else {
+    return null;
   }
+};
+
+interface InfoPanelProps {
+  title: string;
+  onClose: () => void;
+}
+
+const InfoPanel: React.FC<PropsWithChildren<InfoPanelProps>> = ({
+  title,
+  onClose,
+  children,
+}) => {
+  return (
+    <div id="panel" className="panel">
+      <div id="panel-content" className="panel-content">
+        <button
+          id="panel-close"
+          className="close-button"
+          aria-label="Lukk"
+          onClick={onClose}
+        >
+          &times;
+        </button>
+
+        <h1 id="feature-name">{title}</h1>
+
+        <div className="panel-body">{children}</div>
+      </div>
+    </div>
+  );
+};
+
+interface FeatureInfoProps {
+  feature: Feature;
+}
+const FeatureInfo: React.FC<FeatureInfoProps> = ({ feature }) => {
+  const address = formatAddress(feature.address);
+
+  return (
+    <>
+      <KindBadge kind={feature.kind} />
+
+      {address && <div> {address} </div>}
+      {feature.description && (
+        <p id="feature-description">{feature.description}</p>
+      )}
+
+      {feature?.opening_hours && (
+        <OpeningHours openingHours={feature.opening_hours} />
+      )}
+
+      {feature.website && (
+        <a href={feature.website} target="_blank">
+          Nettside
+        </a>
+      )}
+      {feature.facebook && (
+        <a href={feature.facebook} target="_blank">
+          Facebook
+        </a>
+      )}
+
+      <a
+        className="edit-link"
+        href={makeRapidURL(feature.long, feature.lat, feature.id)}
+        target="_blank"
+        rel="noreferrer"
+      >
+        Oppdater informasjon
+      </a>
+    </>
+  );
+};
+
+const ServiceInfo = () => {
+  return (
+    <>
+      <p>Denne tjenesten er utviklet av Fremtiden i Våre Hender Bergen.</p>
+    </>
+  );
 };

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,12 +3,14 @@ import { Filter } from "../components/Filter";
 import { Map } from "../components/Map";
 import { Panel } from "../components/Panel";
 import Layout from "../layouts/Layout.astro";
+import InfoBadge from "../components/InfoBadge.astro";
 ---
 
 <Layout>
   <Map client:only="react" />
   <Panel client:only="react" />
   <Filter client:only="react" />
+  <InfoBadge />
 </Layout>
 
 <script>

--- a/src/store/feature.ts
+++ b/src/store/feature.ts
@@ -1,7 +1,7 @@
 import { atom } from "nanostores";
 import type { FeatureData } from "../overpass/features";
 
-type Feature = {
+export type Feature = {
   kind: "repair" | "rental" | "second-hand";
   lat: number;
   long: number;
@@ -41,6 +41,10 @@ export function setFeature(feature: FeatureData) {
       city: feature.properties["addr:city"],
     },
   });
+}
+
+export function clearFeature() {
+  $feature.set(null);
 }
 
 export const $showInfoPanel = atom(false);


### PR DESCRIPTION
The Panel component can now serve two purposes; showing info about this service, or show info about a feature on the map. The InfoBadge component is a clickable element in the top right corner which opens up the info panel to show the general info.