### PR TITLE
refactor: allow commits from fetch-features to trigger deployment

### DIFF
--- a/.github/workflows/fetch-features.yml
+++ b/.github/workflows/fetch-features.yml
@@ -50,10 +50,3 @@ jobs:
         if: env.CHANGED == 'true'
         with:
           commit_message: "chore: update OSM data"
-          commit_options: "--no-verify"
-  deploy:
-    permissions:
-      pages: write
-      id-token: write
-      contents: read
-    uses: fivh-bergen/kart/.github/workflows/deploy.yml@main


### PR DESCRIPTION
Following from #49, it's more effecient to let this workflow trigger a deployment via the commit since it will only be committing when it needs to. Removing no-verify enables this behaviour.