### PR TITLE
fix: hide labels initially

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -86,6 +86,7 @@ import InfoBadge from "../components/InfoBadge.astro";
     --display-repair: block;
     --display-second-hand: block;
     --display-rental: block;
+    --display-label: none;
   }
 
   .marker-flex {


### PR DESCRIPTION
The labels should not show on the default zoom level. They will update when zooming