### PR TITLE
feat: add support for human readable tags

### DIFF
--- a/src/store/feature.ts
+++ b/src/store/feature.ts
@@ -56,3 +56,24 @@ export function showInfoPanel() {
 export function hideInfoPanel() {
   $showInfoPanel.set(false);
 }
+
+export enum Tag {
+  SecondHandShop = "Bruktbutikk",
+  WomensClothes = "Kvinneklær",
+  MensClothes = "Herreklær",
+  ChildrensClothes = "Barneklær",
+  GiveBox = "Gi bort-boks",
+  BicycleRepair = "Sykkelreparasjon",
+  AssistedSelfService = "Selvbetjening",
+  ComputerRepair = "Datareparasjon",
+  MobilePhoneRepair = "Telefonreparasjon",
+  CameraRepair = "Kamerareparasjon",
+  RepairCafe = "Repair Café",
+  BicycleRental = "Sykkelutleie",
+  BoatRental = "Båtutleie",
+  MotorcycleRental = "Motorsykkelutleie",
+  ScooterRental = "Scooterutleie",
+  SkiRental = "Skiutleie",
+  ToolHireShop = "Verktøyutleie",
+  ToyLibrary = "Lekeutleie",
+}


### PR DESCRIPTION
This will take some work. There are quite a few tags to care about. The clothes tag should have more detailed tags, for example.

My thinking is that we will map from OSM tags to our own enum here, then we render our enum values as badges in the info panel. Some OSM tags are effectively saying the same thing, such as `"service:bicycle:repair"="yes"` and `"bicycle:repair"="yes"`.