### PR TITLE
feat: deploy app on feature update

### DIFF
--- a/.github/workflows/fetch-features.yml
+++ b/.github/workflows/fetch-features.yml
@@ -13,6 +13,8 @@ jobs:
       # Give the default GITHUB_TOKEN write permission to commit and push the
       # added or changed files to the repository.
       contents: write
+      pages: write
+      id-token: write
 
     steps:
       - uses: actions/checkout@v4
@@ -50,3 +52,5 @@ jobs:
         if: env.CHANGED == 'true'
         with:
           commit_message: "chore: update OSM data"
+      - uses: fivh-bergen/kart/.github/workflows/deploy.yml@main
+        if: env.CHANGED == 'true'


### PR DESCRIPTION
We want the actual page to update itself, not just the code! I was mistaken in #50, the github bot's commit will not trigger workflows by default.