### PR TITLE
fix: deploy after fetching features

### DIFF
--- a/.github/workflows/fetch-features.yml
+++ b/.github/workflows/fetch-features.yml
@@ -52,5 +52,10 @@ jobs:
         if: env.CHANGED == 'true'
         with:
           commit_message: "chore: update OSM data"
-      - uses: fivh-bergen/kart/.github/workflows/deploy.yml@main
-        if: env.CHANGED == 'true'
+
+  deploy:
+    permissions:
+      pages: write
+      id-token: write
+      contents: read
+    uses: fivh-bergen/kart/.github/workflows/deploy.yml@main


### PR DESCRIPTION
My past attempts have failed. Here I am just calling the deploy workflow without caring about whether any changes have actually occured. Slightly wasteful use of github action runners, but it won't affect the git history, at least