### PR TITLE
refactor: simplify fetch-nodes-script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,8 +22,3 @@ pnpm-debug.log*
 
 # jetbrains setting folder
 .idea/
-
-# Intermediate OSM data files
-src/overpass/data/rental.osmjson
-src/overpass/data/repair.osmjson
-src/overpass/data/second-hand.osmjson

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test:spec": "vitest --exclude \"**/*.test.ts\"",
     "format:check": "prettier --check \"**/*.{js,jsx,ts,tsx,md}\"",
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,md}\"",
-    "fetch-nodes": "node src/overpass/fetch-data.js && osmtogeojson src/overpass/data/repair.osmjson > src/overpass/data/repair.json && osmtogeojson src/overpass/data/rental.osmjson > src/overpass/data/rental.json && osmtogeojson src/overpass/data/second-hand.osmjson > src/overpass/data/second-hand.json"
+    "fetch-nodes": "ts-node src/overpass/fetch-data.ts"
   },
   "dependencies": {
     "@astrojs/react": "^4.2.0",
@@ -35,6 +35,7 @@
     "@types/react-dom": "^19.0.3",
     "osmtogeojson": "3.0.0-beta.5",
     "prettier": "^3.4.2",
+    "ts-node": "^10.9.2",
     "vitest": "^3.0.8"
   },
   "packageManager": "pnpm@9.14.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
       prettier:
         specifier: ^3.4.2
         version: 3.4.2
+      ts-node:
+        specifier: ^10.9.2
+        version: 10.9.2(@types/node@22.13.0)(typescript@5.7.3)
       vitest:
         specifier: ^3.0.8
         version: 3.0.8(@types/debug@4.1.12)(@types/node@22.13.0)
@@ -189,6 +192,10 @@ packages:
   '@babel/types@7.26.7':
     resolution: {integrity: sha512-t8kDRGrKXyp6+tjUh7hw2RLyclsW4TRoRvRHtSyAX9Bb5ldlFh+90YAYY6awRXrlB4G5G2izNeGySpATlFzmOg==}
     engines: {node: '>=6.9.0'}
+
+  '@cspotcode/source-map-support@0.8.1':
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
+    engines: {node: '>=12'}
 
   '@emnapi/runtime@1.3.1':
     resolution: {integrity: sha512-kEBmG8KyqtxJZv+ygbEim+KCGtIq1fC22Ms3S4ziXmYKm8uyoLX0MHONVKwp+9opg390VaKRNt4a7A9NwmpNhw==}
@@ -466,6 +473,9 @@ packages:
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
 
+  '@jridgewell/trace-mapping@0.3.9':
+    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+
   '@mapbox/geojson-rewind@0.5.2':
     resolution: {integrity: sha512-tJaT+RbYGJYStt7wI3cq4Nl4SXxG8W7JDG5DMJu97V25RnbNg3QtQtf+KD+VLjNpWKYsRvXDNmNrBgEETr1ifA==}
     hasBin: true
@@ -641,6 +651,18 @@ packages:
   '@shikijs/vscode-textmate@10.0.1':
     resolution: {integrity: sha512-fTIQwLF+Qhuws31iw7Ncl1R3HUDtGwIipiJ9iU+UsDUwMhegFcQKQHd51nZjb7CArq0MvON8rbgCGQYWHUKAdg==}
 
+  '@tsconfig/node10@1.0.11':
+    resolution: {integrity: sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==}
+
+  '@tsconfig/node12@1.0.11':
+    resolution: {integrity: sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==}
+
+  '@tsconfig/node14@1.0.3':
+    resolution: {integrity: sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==}
+
+  '@tsconfig/node16@1.0.4':
+    resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
+
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
 
@@ -755,6 +777,10 @@ packages:
   JSONStream@0.8.0:
     resolution: {integrity: sha512-PiV28BpoUorz9kKFwRbD7+wg0t/k0ITHKn0DgCU44YZ/GaGAZRPt9q5PzoifC85gE55SEPIdMu0Labfxevj8cw==}
 
+  acorn-walk@8.3.4:
+    resolution: {integrity: sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==}
+    engines: {node: '>=0.4.0'}
+
   acorn@8.14.0:
     resolution: {integrity: sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==}
     engines: {node: '>=0.4.0'}
@@ -778,6 +804,9 @@ packages:
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
+
+  arg@4.1.3:
+    resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
 
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
@@ -923,6 +952,9 @@ packages:
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
 
+  create-require@1.1.1:
+    resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
+
   crossws@0.3.3:
     resolution: {integrity: sha512-/71DJT3xJlqSnBr83uGJesmVHSzZEvgxHt/fIKxBAAngqMHmnBWQNxCphVxxJ2XL3xleu5+hJD6IQ3TglBedcw==}
 
@@ -976,6 +1008,10 @@ packages:
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
+
+  diff@4.0.2:
+    resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
+    engines: {node: '>=0.3.1'}
 
   diff@5.2.0:
     resolution: {integrity: sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==}
@@ -1310,6 +1346,9 @@ packages:
 
   magicast@0.3.5:
     resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
+
+  make-error@1.3.6:
+    resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
 
   maplibre-gl@5.0.1:
     resolution: {integrity: sha512-kNvod1Tq0BcZvn43UAciA3DrzaEGmowqMoI6nh3kUo9rf+7m89mFJI9dELxkWzJ/N9Pgnkp7xF1jzTP08PGpCw==}
@@ -1844,6 +1883,20 @@ packages:
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
 
+  ts-node@10.9.2:
+    resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': '>=1.2.50'
+      '@swc/wasm': '>=1.2.50'
+      '@types/node': '*'
+      typescript: '>=2.7'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      '@swc/wasm':
+        optional: true
+
   tsconfck@3.1.4:
     resolution: {integrity: sha512-kdqWFGVJqe+KGYvlSO9NIaWn9jT1Ny4oKVzAJsKii5eoE9snzTJzL4+MMVOMn+fikWGFmKEylcXL710V/kIPJQ==}
     engines: {node: ^18 || >=20}
@@ -1982,6 +2035,9 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
+  v8-compile-cache-lib@3.0.1:
+    resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
+
   vfile-location@5.0.3:
     resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}
 
@@ -2117,6 +2173,10 @@ packages:
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
+
+  yn@3.1.1:
+    resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
+    engines: {node: '>=6'}
 
   yocto-queue@1.1.1:
     resolution: {integrity: sha512-b4JR1PFR10y1mKjhHY9LaGo6tmrgjit7hxVIeAmyMw3jegXR4dhYqLaQF5zMXZxY7tLpMyJeLjr1C4rLmkVe8g==}
@@ -2339,6 +2399,10 @@ snapshots:
       '@babel/helper-string-parser': 7.25.9
       '@babel/helper-validator-identifier': 7.25.9
 
+  '@cspotcode/source-map-support@0.8.1':
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.9
+
   '@emnapi/runtime@1.3.1':
     dependencies:
       tslib: 2.8.1
@@ -2511,6 +2575,11 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
 
+  '@jridgewell/trace-mapping@0.3.9':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.0
+
   '@mapbox/geojson-rewind@0.5.2':
     dependencies:
       get-stream: 6.0.1
@@ -2659,6 +2728,14 @@ snapshots:
 
   '@shikijs/vscode-textmate@10.0.1': {}
 
+  '@tsconfig/node10@1.0.11': {}
+
+  '@tsconfig/node12@1.0.11': {}
+
+  '@tsconfig/node14@1.0.3': {}
+
+  '@tsconfig/node16@1.0.4': {}
+
   '@types/babel__core@7.20.5':
     dependencies:
       '@babel/parser': 7.26.7
@@ -2798,6 +2875,10 @@ snapshots:
       jsonparse: 0.0.5
       through: 2.2.7
 
+  acorn-walk@8.3.4:
+    dependencies:
+      acorn: 8.14.0
+
   acorn@8.14.0: {}
 
   ansi-align@3.0.1:
@@ -2814,6 +2895,8 @@ snapshots:
     dependencies:
       normalize-path: 3.0.0
       picomatch: 2.3.1
+
+  arg@4.1.3: {}
 
   argparse@1.0.10:
     dependencies:
@@ -3041,6 +3124,8 @@ snapshots:
 
   core-util-is@1.0.3: {}
 
+  create-require@1.1.1: {}
+
   crossws@0.3.3:
     dependencies:
       uncrypto: 0.1.3
@@ -3079,6 +3164,8 @@ snapshots:
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
+
+  diff@4.0.2: {}
 
   diff@5.2.0: {}
 
@@ -3443,6 +3530,8 @@ snapshots:
       '@babel/parser': 7.26.7
       '@babel/types': 7.26.7
       source-map-js: 1.2.1
+
+  make-error@1.3.6: {}
 
   maplibre-gl@5.0.1:
     dependencies:
@@ -4255,6 +4344,24 @@ snapshots:
 
   trough@2.2.0: {}
 
+  ts-node@10.9.2(@types/node@22.13.0)(typescript@5.7.3):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.11
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 22.13.0
+      acorn: 8.14.0
+      acorn-walk: 8.3.4
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.7.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+
   tsconfck@3.1.4(typescript@5.7.3):
     optionalDependencies:
       typescript: 5.7.3
@@ -4354,6 +4461,8 @@ snapshots:
       picocolors: 1.1.1
 
   util-deprecate@1.0.2: {}
+
+  v8-compile-cache-lib@3.0.1: {}
 
   vfile-location@5.0.3:
     dependencies:
@@ -4483,6 +4592,8 @@ snapshots:
   yallist@3.1.1: {}
 
   yargs-parser@21.1.1: {}
+
+  yn@3.1.1: {}
 
   yocto-queue@1.1.1: {}
 

--- a/src/overpass/data/rental.json
+++ b/src/overpass/data/rental.json
@@ -1,102 +1,102 @@
 {
-"type": "FeatureCollection",
-"features": [
-{
-  "type": "Feature",
-  "id": "node/5893480259",
-  "properties": {
-    "amenity": "boat_rental",
-    "contact:facebook": "https://nb-no.facebook.com/Sandvikenkystlag",
-    "name": "Bergen Båtdelering",
-    "note": "Bestilling av båtene gjøres via Facebookgruppen – Bergen Båtdelering (lukket gruppe for de som har betalt kontingent/BB faktura). Kano bestilles ved å sende sms til Gerhard på 90870382.",
-    "operator": "Sandviken kystlag",
-    "website": "https://www.sandvikenkystlag.com/bergen-b%C3%A5tdelering.php",
-    "id": "node/5893480259"
-  },
-  "geometry": {
-    "type": "Point",
-    "coordinates": [
-      5.3218983,
-      60.4080995
-    ]
-  }
-},
-{
-  "type": "Feature",
-  "id": "node/6054933076",
-  "properties": {
-    "amenity": "bicycle_rental",
-    "bicycle": "mtb",
-    "bicycle_rental": "dropoff_point",
-    "building": "yes",
-    "name": "Fløyen Aktiv",
-    "opening_hours": "May-Sep PH,Mo-Su 10:00-15:00",
-    "operator": "Fløibanen AS",
-    "phone": "+47 47 68 15 05",
-    "id": "node/6054933076"
-  },
-  "geometry": {
-    "type": "Point",
-    "coordinates": [
-      5.3443121,
-      60.3948652
-    ]
-  }
-},
-{
-  "type": "Feature",
-  "id": "node/12435651069",
-  "properties": {
-    "amenity": "bicycle_rental",
-    "name": "Bergen Bike Rent",
-    "phone": "+ 47 410 68 000",
-    "website": "https://www.norwayactive.no/",
-    "id": "node/12435651069"
-  },
-  "geometry": {
-    "type": "Point",
-    "coordinates": [
-      5.3168632,
-      60.4017274
-    ]
-  }
-},
-{
-  "type": "Feature",
-  "id": "node/12435651070",
-  "properties": {
-    "name": "Fløyen Aktiv",
-    "shop": "rental",
-    "id": "node/12435651070"
-  },
-  "geometry": {
-    "type": "Point",
-    "coordinates": [
-      5.344336,
-      60.3948596
-    ]
-  }
-},
-{
-  "type": "Feature",
-  "id": "node/12622866775",
-  "properties": {
-    "addr:city": "Bergen",
-    "addr:housenumber": "6",
-    "addr:postcode": "5008",
-    "addr:street": "Agnes Mowinckels gate",
-    "name": "Skattkammeret Bergen",
-    "phone": "469 81 234",
-    "shop": "rental",
-    "id": "node/12622866775"
-  },
-  "geometry": {
-    "type": "Point",
-    "coordinates": [
-      5.3325181,
-      60.3862139
-    ]
-  }
-}
-]
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "id": "node/5893480259",
+      "properties": {
+        "amenity": "boat_rental",
+        "contact:facebook": "https://nb-no.facebook.com/Sandvikenkystlag",
+        "name": "Bergen Båtdelering",
+        "note": "Bestilling av båtene gjøres via Facebookgruppen – Bergen Båtdelering (lukket gruppe for de som har betalt kontingent/BB faktura). Kano bestilles ved å sende sms til Gerhard på 90870382.",
+        "operator": "Sandviken kystlag",
+        "website": "https://www.sandvikenkystlag.com/bergen-b%C3%A5tdelering.php",
+        "id": "node/5893480259"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          5.3218983,
+          60.4080995
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "node/6054933076",
+      "properties": {
+        "amenity": "bicycle_rental",
+        "bicycle": "mtb",
+        "bicycle_rental": "dropoff_point",
+        "building": "yes",
+        "name": "Fløyen Aktiv",
+        "opening_hours": "May-Sep PH,Mo-Su 10:00-15:00",
+        "operator": "Fløibanen AS",
+        "phone": "+47 47 68 15 05",
+        "id": "node/6054933076"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          5.3443121,
+          60.3948652
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "node/12435651069",
+      "properties": {
+        "amenity": "bicycle_rental",
+        "name": "Bergen Bike Rent",
+        "phone": "+ 47 410 68 000",
+        "website": "https://www.norwayactive.no/",
+        "id": "node/12435651069"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          5.3168632,
+          60.4017274
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "node/12435651070",
+      "properties": {
+        "name": "Fløyen Aktiv",
+        "shop": "rental",
+        "id": "node/12435651070"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          5.344336,
+          60.3948596
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "node/12622866775",
+      "properties": {
+        "addr:city": "Bergen",
+        "addr:housenumber": "6",
+        "addr:postcode": "5008",
+        "addr:street": "Agnes Mowinckels gate",
+        "name": "Skattkammeret Bergen",
+        "phone": "469 81 234",
+        "shop": "rental",
+        "id": "node/12622866775"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          5.3325181,
+          60.3862139
+        ]
+      }
+    }
+  ]
 }

--- a/src/overpass/data/repair.json
+++ b/src/overpass/data/repair.json
@@ -1,238 +1,238 @@
 {
-"type": "FeatureCollection",
-"features": [
-{
-  "type": "Feature",
-  "id": "node/289529117",
-  "properties": {
-    "email": "post@trekbergen.no",
-    "name": "Trek Bergen",
-    "opening_hours": "Mo-Th 10:00-19:00; Fr 10:00-18:00; Sa 10:00-16:00",
-    "phone": "+47 55 27 14 50",
-    "service:bicycle:repair": "yes",
-    "service:bicycle:retail": "yes",
-    "shop": "bicycle",
-    "website": "https://trekbergen.no/",
-    "id": "node/289529117"
-  },
-  "geometry": {
-    "type": "Point",
-    "coordinates": [
-      5.336896,
-      60.3507129
-    ]
-  }
-},
-{
-  "type": "Feature",
-  "id": "node/1470638881",
-  "properties": {
-    "community_centre": "bicycle_maintenance",
-    "contact:facebook": "https://www.facebook.com/pedalenbergen",
-    "email": "pedalen@bymisjon.no",
-    "name": "Pedalen",
-    "opening_hours": "Mo, Fr 08:30-16:00; Tu, Th 08:30-17:00; We 08:30-18:00",
-    "operator": "Kirkens Bymisjon i Bergen",
-    "ownership": "private_nonprofit",
-    "phone": "+47 55 61 20 00",
-    "service:bicycle:parts": "yes",
-    "service:bicycle:pump": "yes",
-    "service:bicycle:repair": "yes",
-    "service:bicycle:second_hand": "yes",
-    "service:bicycle:service": "yes",
-    "shop": "bicycle",
-    "website": "https://kirkensbymisjon.no/pedalen-sykkelverksted-bergen/",
-    "wheelchair": "yes",
-    "id": "node/1470638881"
-  },
-  "geometry": {
-    "type": "Point",
-    "coordinates": [
-      5.3324536,
-      60.3862669
-    ]
-  }
-},
-{
-  "type": "Feature",
-  "id": "node/3575013102",
-  "properties": {
-    "branch": "Horisont",
-    "brand": "XXL",
-    "brand:wikidata": "Q12010840",
-    "email": "post.asane@xxl.no",
-    "level": "1",
-    "name": "XXL",
-    "opening_hours": "Mo-Fr 10:00-21:00; Sa 10:00-18:00",
-    "payment:bankaxept": "yes",
-    "payment:cash": "yes",
-    "payment:debit_cards": "yes",
-    "phone": "+47 24 08 46 75",
-    "service:bicycle:dealer": "yes",
-    "service:bicycle:ebike": "yes",
-    "service:bicycle:repair": "yes",
-    "service:bicycle:retail": "yes",
-    "service:bicycle:sales": "yes",
-    "shop": "sports",
-    "sport": "fitness;table_tennis;soccer;basketball;multi;tennis;gymnastics;shooting;scuba_diving;equestrian;baseball;skateboard;disc_golf;volleyball;athletics;cycling;golf;ice_hockey;ice_skating;running;skiing;handball;swimming;american_football;badminton;climbing",
-    "stroller": "yes",
-    "website": "https://www.xxl.no/store-finder/sportsbutikk-bergen/asane",
-    "wheelchair": "yes",
-    "id": "node/3575013102"
-  },
-  "geometry": {
-    "type": "Point",
-    "coordinates": [
-      5.3226843,
-      60.4704744
-    ]
-  }
-},
-{
-  "type": "Feature",
-  "id": "node/3946010595",
-  "properties": {
-    "craft": "shoemaker",
-    "name": "Skomaker",
-    "id": "node/3946010595"
-  },
-  "geometry": {
-    "type": "Point",
-    "coordinates": [
-      5.322213,
-      60.391204
-    ]
-  }
-},
-{
-  "type": "Feature",
-  "id": "node/3962005407",
-  "properties": {
-    "alt_name": "Skomaker S Kalleklev",
-    "craft": "shoemaker",
-    "name": "Skomaker O Såle Mio",
-    "opening_hours": "Mo-Th 10:13-15:00",
-    "phone": "+47 55 32 39 82",
-    "id": "node/3962005407"
-  },
-  "geometry": {
-    "type": "Point",
-    "coordinates": [
-      5.321672,
-      60.39034
-    ]
-  }
-},
-{
-  "type": "Feature",
-  "id": "node/3962005408",
-  "properties": {
-    "craft": "shoemaker",
-    "name": "Skomakeren i Marken",
-    "opening_hours": "Mo-We 10:00-16:00; Th 10:00-17:00; Fr 10:00-16:00",
-    "phone": "40514748",
-    "shop": "leather",
-    "website": "http://www.bergenskomaker.no/",
-    "id": "node/3962005408"
-  },
-  "geometry": {
-    "type": "Point",
-    "coordinates": [
-      5.33014,
-      60.392358
-    ]
-  }
-},
-{
-  "type": "Feature",
-  "id": "node/3984672557",
-  "properties": {
-    "brand": "Sony",
-    "craft": "electronics_repair",
-    "name": "Sony Servicekompaniet",
-    "repair": "only",
-    "shop": "electronics_repair",
-    "website": "http://www.servicekompaniet.no/",
-    "id": "node/3984672557"
-  },
-  "geometry": {
-    "type": "Point",
-    "coordinates": [
-      5.30846,
-      60.398878
-    ]
-  }
-},
-{
-  "type": "Feature",
-  "id": "node/4235820783",
-  "properties": {
-    "craft": "shoemaker",
-    "level": "0",
-    "name": "Skomakeren i Oasen",
-    "id": "node/4235820783"
-  },
-  "geometry": {
-    "type": "Point",
-    "coordinates": [
-      5.2897439,
-      60.3493112
-    ]
-  }
-},
-{
-  "type": "Feature",
-  "id": "node/5830546093",
-  "properties": {
-    "check_date:opening_hours": "2022-09-18",
-    "craft": "shoemaker",
-    "name": "Fot i hosen",
-    "opening_hours:signed": "no",
-    "id": "node/5830546093"
-  },
-  "geometry": {
-    "type": "Point",
-    "coordinates": [
-      5.3215994,
-      60.3902788
-    ]
-  }
-},
-{
-  "type": "Feature",
-  "id": "node/12409128717",
-  "properties": {
-    "name": "Cyclofix",
-    "service:bicycle:repair": "yes",
-    "shop": "bicycle",
-    "website": "https://www.cyclofix.no/",
-    "id": "node/12409128717"
-  },
-  "geometry": {
-    "type": "Point",
-    "coordinates": [
-      5.3425365,
-      60.3532879
-    ]
-  }
-},
-{
-  "type": "Feature",
-  "id": "node/12409128718",
-  "properties": {
-    "name": "Bici Bergen",
-    "service:bicycle:repair": "yes",
-    "shop": "bicycle",
-    "website": "https://www.bicibergen.no/",
-    "id": "node/12409128718"
-  },
-  "geometry": {
-    "type": "Point",
-    "coordinates": [
-      5.322958,
-      60.4047985
-    ]
-  }
-}
-]
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "id": "node/289529117",
+      "properties": {
+        "email": "post@trekbergen.no",
+        "name": "Trek Bergen",
+        "opening_hours": "Mo-Th 10:00-19:00; Fr 10:00-18:00; Sa 10:00-16:00",
+        "phone": "+47 55 27 14 50",
+        "service:bicycle:repair": "yes",
+        "service:bicycle:retail": "yes",
+        "shop": "bicycle",
+        "website": "https://trekbergen.no/",
+        "id": "node/289529117"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          5.336896,
+          60.3507129
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "node/1470638881",
+      "properties": {
+        "community_centre": "bicycle_maintenance",
+        "contact:facebook": "https://www.facebook.com/pedalenbergen",
+        "email": "pedalen@bymisjon.no",
+        "name": "Pedalen",
+        "opening_hours": "Mo, Fr 08:30-16:00; Tu, Th 08:30-17:00; We 08:30-18:00",
+        "operator": "Kirkens Bymisjon i Bergen",
+        "ownership": "private_nonprofit",
+        "phone": "+47 55 61 20 00",
+        "service:bicycle:parts": "yes",
+        "service:bicycle:pump": "yes",
+        "service:bicycle:repair": "yes",
+        "service:bicycle:second_hand": "yes",
+        "service:bicycle:service": "yes",
+        "shop": "bicycle",
+        "website": "https://kirkensbymisjon.no/pedalen-sykkelverksted-bergen/",
+        "wheelchair": "yes",
+        "id": "node/1470638881"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          5.3324536,
+          60.3862669
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "node/3575013102",
+      "properties": {
+        "branch": "Horisont",
+        "brand": "XXL",
+        "brand:wikidata": "Q12010840",
+        "email": "post.asane@xxl.no",
+        "level": "1",
+        "name": "XXL",
+        "opening_hours": "Mo-Fr 10:00-21:00; Sa 10:00-18:00",
+        "payment:bankaxept": "yes",
+        "payment:cash": "yes",
+        "payment:debit_cards": "yes",
+        "phone": "+47 24 08 46 75",
+        "service:bicycle:dealer": "yes",
+        "service:bicycle:ebike": "yes",
+        "service:bicycle:repair": "yes",
+        "service:bicycle:retail": "yes",
+        "service:bicycle:sales": "yes",
+        "shop": "sports",
+        "sport": "fitness;table_tennis;soccer;basketball;multi;tennis;gymnastics;shooting;scuba_diving;equestrian;baseball;skateboard;disc_golf;volleyball;athletics;cycling;golf;ice_hockey;ice_skating;running;skiing;handball;swimming;american_football;badminton;climbing",
+        "stroller": "yes",
+        "website": "https://www.xxl.no/store-finder/sportsbutikk-bergen/asane",
+        "wheelchair": "yes",
+        "id": "node/3575013102"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          5.3226843,
+          60.4704744
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "node/3946010595",
+      "properties": {
+        "craft": "shoemaker",
+        "name": "Skomaker",
+        "id": "node/3946010595"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          5.322213,
+          60.391204
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "node/3962005407",
+      "properties": {
+        "alt_name": "Skomaker S Kalleklev",
+        "craft": "shoemaker",
+        "name": "Skomaker O Såle Mio",
+        "opening_hours": "Mo-Th 10:13-15:00",
+        "phone": "+47 55 32 39 82",
+        "id": "node/3962005407"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          5.321672,
+          60.39034
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "node/3962005408",
+      "properties": {
+        "craft": "shoemaker",
+        "name": "Skomakeren i Marken",
+        "opening_hours": "Mo-We 10:00-16:00; Th 10:00-17:00; Fr 10:00-16:00",
+        "phone": "40514748",
+        "shop": "leather",
+        "website": "http://www.bergenskomaker.no/",
+        "id": "node/3962005408"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          5.33014,
+          60.392358
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "node/3984672557",
+      "properties": {
+        "brand": "Sony",
+        "craft": "electronics_repair",
+        "name": "Sony Servicekompaniet",
+        "repair": "only",
+        "shop": "electronics_repair",
+        "website": "http://www.servicekompaniet.no/",
+        "id": "node/3984672557"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          5.30846,
+          60.398878
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "node/4235820783",
+      "properties": {
+        "craft": "shoemaker",
+        "level": "0",
+        "name": "Skomakeren i Oasen",
+        "id": "node/4235820783"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          5.2897439,
+          60.3493112
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "node/5830546093",
+      "properties": {
+        "check_date:opening_hours": "2022-09-18",
+        "craft": "shoemaker",
+        "name": "Fot i hosen",
+        "opening_hours:signed": "no",
+        "id": "node/5830546093"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          5.3215994,
+          60.3902788
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "node/12409128717",
+      "properties": {
+        "name": "Cyclofix",
+        "service:bicycle:repair": "yes",
+        "shop": "bicycle",
+        "website": "https://www.cyclofix.no/",
+        "id": "node/12409128717"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          5.3425365,
+          60.3532879
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "node/12409128718",
+      "properties": {
+        "name": "Bici Bergen",
+        "service:bicycle:repair": "yes",
+        "shop": "bicycle",
+        "website": "https://www.bicibergen.no/",
+        "id": "node/12409128718"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          5.322958,
+          60.4047985
+        ]
+      }
+    }
+  ]
 }

--- a/src/overpass/data/second-hand.json
+++ b/src/overpass/data/second-hand.json
@@ -1,501 +1,501 @@
 {
-"type": "FeatureCollection",
-"features": [
-{
-  "type": "Feature",
-  "id": "node/360298302",
-  "properties": {
-    "addr:city": "Bergen",
-    "addr:housenumber": "55",
-    "addr:postcode": "5006",
-    "addr:street": "Professor Hansteens gate",
-    "check_date:opening_hours": "2023-12-06",
-    "contact:facebook": "https://www.facebook.com/miljomarked/?locale=nb_NO",
-    "description": "Miljømarked Bruktbygg, eller “Miljømarkedet”, er Norges Miljøvernforbunds bruktbutikk, og holder til i det verneverdige Monclairhuset på Møhlenpris. Bruktbutikken tar imot og selger alt med gjenbruksverdi: bøker, klær, elektronikk, byggevarer, pyntegjenst",
-    "name": "Miljømarkedet",
-    "opening_hours": "Mo-Fr 10:00-16:30; Sa 11:00-15:00; PH,Su off",
-    "operator": "Norges Miljøvernforbunds",
-    "phone": "+47 940 05 571",
-    "second_hand": "yes",
-    "shop": "second_hand",
-    "id": "node/360298302"
-  },
-  "geometry": {
-    "type": "Point",
-    "coordinates": [
-      5.3182887,
-      60.3855342
-    ]
-  }
-},
-{
-  "type": "Feature",
-  "id": "node/3684649521",
-  "properties": {
-    "email": "bergen@nlmgjenbruk.no",
-    "name": "Nlm Gjenbruk Bergen",
-    "opening_hours": "We-Fr 12:00-17:00; Sa 11:00-15:00",
-    "phone": "+4740443470",
-    "shop": "second_hand",
-    "id": "node/3684649521"
-  },
-  "geometry": {
-    "type": "Point",
-    "coordinates": [
-      5.454787,
-      60.362588
-    ]
-  }
-},
-{
-  "type": "Feature",
-  "id": "node/3946005930",
-  "properties": {
-    "name": "Vitti",
-    "opening_hours": "Tu-Th 12:00-19:00; Fr-Sa 12:00-18:00",
-    "second_hand": "yes",
-    "shop": "clothes",
-    "id": "node/3946005930"
-  },
-  "geometry": {
-    "type": "Point",
-    "coordinates": [
-      5.3216649,
-      60.3926603
-    ]
-  }
-},
-{
-  "type": "Feature",
-  "id": "node/3946005947",
-  "properties": {
-    "clothes": "women;men;workwear;suits;denim",
-    "name": "Episode",
-    "opening_hours": "Mo-Sa 11:00-19:00",
-    "second_hand": "yes",
-    "shop": "clothes",
-    "id": "node/3946005947"
-  },
-  "geometry": {
-    "type": "Point",
-    "coordinates": [
-      5.3215392,
-      60.392856
-    ]
-  }
-},
-{
-  "type": "Feature",
-  "id": "node/3946005953",
-  "properties": {
-    "description": "Kjøp og salg av hvitevarer og brunevarer",
-    "name": "Nygårdsgaten Brukthandel",
-    "opening_hours": "Mo-Fr 10:00-19:30; Sa 10:00-17:30; Su off",
-    "shop": "second_hand",
-    "id": "node/3946005953"
-  },
-  "geometry": {
-    "type": "Point",
-    "coordinates": [
-      5.3288111,
-      60.3872358
-    ]
-  }
-},
-{
-  "type": "Feature",
-  "id": "node/3964625325",
-  "properties": {
-    "name": "NMS Gjenbruk Bergen",
-    "opening_hours": "Mo-We 10:30-16:30; Th 10:30-17:30; Fr 10:30-16:30; Sa 11:00-15:00",
-    "operator": "Det Norske Misjonsselskap",
-    "second_hand": "yes",
-    "shop": "charity",
-    "website": "https://nms.no/butikk/bergen/",
-    "id": "node/3964625325"
-  },
-  "geometry": {
-    "type": "Point",
-    "coordinates": [
-      5.322427,
-      60.399174
-    ]
-  }
-},
-{
-  "type": "Feature",
-  "id": "node/3988480605",
-  "properties": {
-    "check_date:opening_hours": "2023-10-22",
-    "name": "Rimelige Hvitevarer",
-    "opening_hours": "Mo-Fr 10:00-18:00; Sa 10:00-17:00",
-    "second_hand": "yes",
-    "shop": "appliance",
-    "id": "node/3988480605"
-  },
-  "geometry": {
-    "type": "Point",
-    "coordinates": [
-      5.3226783,
-      60.4008828
-    ]
-  }
-},
-{
-  "type": "Feature",
-  "id": "node/3988501473",
-  "properties": {
-    "opening_hours": "Mo-We 10:30-17:30; Th 10:30-19:00; Fr 10:30-17:00; Sa 10:30-15:00",
-    "second_hand": "yes",
-    "shop": "comics",
-    "id": "node/3988501473"
-  },
-  "geometry": {
-    "type": "Point",
-    "coordinates": [
-      5.3263675,
-      60.3969591
-    ]
-  }
-},
-{
-  "type": "Feature",
-  "id": "node/4086570111",
-  "properties": {
-    "opening_hours": "Th 15:30-17:00; Tu 15:30-17:00",
-    "second_hand": "yes",
-    "shop": "books",
-    "id": "node/4086570111"
-  },
-  "geometry": {
-    "type": "Point",
-    "coordinates": [
-      5.3509386,
-      60.3613502
-    ]
-  }
-},
-{
-  "type": "Feature",
-  "id": "node/4099728387",
-  "properties": {
-    "contact:facebook": "https://www.facebook.com/secondlovelove",
-    "email": "lisa@secondlove.no",
-    "name": "Second Love",
-    "opening_hours": "Mo-We 11:00-16:00; Th-Fr 11:00-18:00; Sa 11:00-17:00",
-    "phone": "+47 413 57 743",
-    "second_hand": "yes",
-    "shop": "clothes",
-    "website": "http://www.secondlove.no/",
-    "id": "node/4099728387"
-  },
-  "geometry": {
-    "type": "Point",
-    "coordinates": [
-      5.328073,
-      60.393835
-    ]
-  }
-},
-{
-  "type": "Feature",
-  "id": "node/4161392159",
-  "properties": {
-    "addr:city": "Bergen",
-    "addr:housenumber": "14-16",
-    "addr:postcode": "5008",
-    "addr:street": "Lars Hilles gate",
-    "brand": "Fretex",
-    "check_date:opening_hours": "2025-01-29",
-    "clothes": "women;men;children;sports;suits;workwear;fashion;unisex",
-    "contact:facebook": "https://www.facebook.com/profile.php?id=100049104231501",
-    "description": "En bruktbutikk i regi av Frelsesarmeen som selger og tar imot blant annet klær, interiørartikler, bøker, sportsutstyr og leker.",
-    "name": "Fretex Lars Hilles gate",
-    "opening_hours": "Mo-Fr 10:00-18:00; Sa 11:00-17:00",
-    "phone": "+47 55321486",
-    "ref:fretex": "132",
-    "second_hand": "yes",
-    "shop": "charity",
-    "toilets:wheelchair": "no",
-    "website": "https://www.fretex.no/handle/finn-butikk/fretex-lars-hillesgate/",
-    "wheelchair": "yes",
-    "id": "node/4161392159"
-  },
-  "geometry": {
-    "type": "Point",
-    "coordinates": [
-      5.330452,
-      60.388668
-    ]
-  }
-},
-{
-  "type": "Feature",
-  "id": "node/4161486173",
-  "properties": {
-    "name": "Mamilla Gjenbruk Bergen",
-    "opening_hours": "Mo-Fr 11:00-17:00; Sa 11:00-15:00",
-    "operator": "Den Norske Israelsmisjon",
-    "second_hand": "only",
-    "shop": "second_hand",
-    "website": "https://www.israelsmisjonen.no/norge/misjonsbutikken/mamilla?fbclid=IwAR2kFPcl8jgaKBqir9MTfFofAlsbbpMhuOx2J2WcLKG_gotKp_7s49aJIm4",
-    "id": "node/4161486173"
-  },
-  "geometry": {
-    "type": "Point",
-    "coordinates": [
-      5.3392101,
-      60.3751804
-    ]
-  }
-},
-{
-  "type": "Feature",
-  "id": "node/4161552886",
-  "properties": {
-    "branch": "Klesskapet i bergen",
-    "clothes": "women",
-    "name": "Det Gule Hus",
-    "second_hand": "only",
-    "shop": "clothes",
-    "website": "https://detgulehus.no/locations/bergen-klesskapet",
-    "id": "node/4161552886"
-  },
-  "geometry": {
-    "type": "Point",
-    "coordinates": [
-      5.346406,
-      60.3721514
-    ]
-  }
-},
-{
-  "type": "Feature",
-  "id": "node/4162069858",
-  "properties": {
-    "name": "Vintage Sisters",
-    "opening_hours": "Fr 12:00-17:00; Sa 12:00-16:00 || \"by appointment\"",
-    "phone": "+47 9719 7274",
-    "second_hand": "yes",
-    "shop": "clothes",
-    "id": "node/4162069858"
-  },
-  "geometry": {
-    "type": "Point",
-    "coordinates": [
-      5.3114323,
-      60.3944318
-    ]
-  }
-},
-{
-  "type": "Feature",
-  "id": "node/4171729440",
-  "properties": {
-    "name": "Bokglede",
-    "opening_hours": "Sa 12:00-16:30",
-    "second_hand": "yes",
-    "shop": "books",
-    "id": "node/4171729440"
-  },
-  "geometry": {
-    "type": "Point",
-    "coordinates": [
-      5.3215394,
-      60.3902272
-    ]
-  }
-},
-{
-  "type": "Feature",
-  "id": "node/5139480162",
-  "properties": {
-    "facebook": "https://www.facebook.com/velbevartbruktbutikk/",
-    "name": "Vel Bevart Bruktbutikk",
-    "opening_hours": "We-Fr 11:00-17:00; Sa 11:00-15:00",
-    "phone": "+47 471 76 460",
-    "second_hand": "only",
-    "shop": "charity",
-    "id": "node/5139480162"
-  },
-  "geometry": {
-    "type": "Point",
-    "coordinates": [
-      5.3674408,
-      60.3583782
-    ]
-  }
-},
-{
-  "type": "Feature",
-  "id": "node/6206106684",
-  "properties": {
-    "brand": "Fretex",
-    "name": "Fretex Åsane",
-    "phone": "+47 55390720",
-    "ref:fretex": "145",
-    "second_hand": "yes",
-    "shop": "charity",
-    "id": "node/6206106684"
-  },
-  "geometry": {
-    "type": "Point",
-    "coordinates": [
-      5.337481,
-      60.4702124
-    ]
-  }
-},
-{
-  "type": "Feature",
-  "id": "node/11012179459",
-  "properties": {
-    "contact:facebook": "https://bir.no/aktuelt/birs-ombruksmarked-hver-tirsdag/",
-    "level": "0",
-    "name": "Nyverdi – BIRs ombruksmarked",
-    "opening_hours": "Tu 14-19",
-    "operator": "BIR AS",
-    "payment:app": "yes",
-    "payment:vipps": "yes",
-    "payment:visa": "yes",
-    "second_hand": "yes",
-    "shop": "second_hand",
-    "id": "node/11012179459"
-  },
-  "geometry": {
-    "type": "Point",
-    "coordinates": [
-      5.3467569,
-      60.3794122
-    ]
-  }
-},
-{
-  "type": "Feature",
-  "id": "node/11922337264",
-  "properties": {
-    "contact:instagram": "https://www.instagram.com/oybergen/",
-    "name": "ÔY",
-    "opening_hours": "Mo-Sa 12:00-18:00",
-    "second_hand": "yes",
-    "shop": "clothes",
-    "id": "node/11922337264"
-  },
-  "geometry": {
-    "type": "Point",
-    "coordinates": [
-      5.3293386,
-      60.3946372
-    ]
-  }
-},
-{
-  "type": "Feature",
-  "id": "node/12087187846",
-  "properties": {
-    "description": "second hand goods free of charge to take - \"freeshop\" - furniture, books, decorations and more",
-    "name": "Brukthallen Bergen",
-    "opening_hours": "Mo-Fr 15-18",
-    "operator": "BIR",
-    "second_hand": "yes",
-    "shop": "second_hand",
-    "id": "node/12087187846"
-  },
-  "geometry": {
-    "type": "Point",
-    "coordinates": [
-      5.3443387,
-      60.3791975
-    ]
-  }
-},
-{
-  "type": "Feature",
-  "id": "node/12184425306",
-  "properties": {
-    "description": "Bergenbruktpc.no er en del av A2G Bjørkhaug, en arbeidsmarkedsbedrift som holder til på Storaneset 12, 5260 Indre Arna. Vi er en arbeidsmakedsbedrift som tilbyr Arbeidsforberedende Trening (AFT), Varig Tilrettelagt Arbeid (VTA), og praksisplasser. Når du",
-    "email": "kontakt@bergenbruktpc.no",
-    "name": "Bergen brukt pc",
-    "opening_hours": "Mo-Fr 09:00-15:00",
-    "operator": "A2G Bjørghaug",
-    "phone": "479 76 151",
-    "second_hand": "yes",
-    "shop": "computer",
-    "website": "https://bergenbruktpc.no/",
-    "id": "node/12184425306"
-  },
-  "geometry": {
-    "type": "Point",
-    "coordinates": [
-      5.464245,
-      60.430984
-    ]
-  }
-},
-{
-  "type": "Feature",
-  "id": "node/12212402786",
-  "properties": {
-    "branch": "Fana",
-    "name": "Det Gule Hus",
-    "second_hand": "only",
-    "shop": "clothes",
-    "website": "https://detgulehus.no/locations/fana",
-    "id": "node/12212402786"
-  },
-  "geometry": {
-    "type": "Point",
-    "coordinates": [
-      5.3278476,
-      60.2952347
-    ]
-  }
-},
-{
-  "type": "Feature",
-  "id": "node/12212402790",
-  "properties": {
-    "branch": "Fyllingsdalen",
-    "fixme": "Vet ikke nøyaktig lokasjon",
-    "name": "Det Gule Hus",
-    "second_hand": "only",
-    "shop": "clothes",
-    "website": "https://detgulehus.no/locations/fyllingsdalen",
-    "id": "node/12212402790"
-  },
-  "geometry": {
-    "type": "Point",
-    "coordinates": [
-      5.2774916,
-      60.3508917
-    ]
-  }
-},
-{
-  "type": "Feature",
-  "id": "node/12236198730",
-  "properties": {
-    "addr:city": "Bergen",
-    "addr:housenumber": "95",
-    "addr:postcode": "5008",
-    "addr:street": "Nygårdsgaten",
-    "clothes": "women;men",
-    "name": "CHAMBR",
-    "opening_hours": "Mo-Fr 11:00-17:00, Sa 11:00-16:00",
-    "payment:cards": "yes",
-    "phone": "702 39 745",
-    "second_hand": "only",
-    "shop": "clothes",
-    "website": "https://www.chambr.no/",
-    "id": "node/12236198730"
-  },
-  "geometry": {
-    "type": "Point",
-    "coordinates": [
-      5.331966,
-      60.3847451
-    ]
-  }
-}
-]
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "id": "node/360298302",
+      "properties": {
+        "addr:city": "Bergen",
+        "addr:housenumber": "55",
+        "addr:postcode": "5006",
+        "addr:street": "Professor Hansteens gate",
+        "check_date:opening_hours": "2023-12-06",
+        "contact:facebook": "https://www.facebook.com/miljomarked/?locale=nb_NO",
+        "description": "Miljømarked Bruktbygg, eller “Miljømarkedet”, er Norges Miljøvernforbunds bruktbutikk, og holder til i det verneverdige Monclairhuset på Møhlenpris. Bruktbutikken tar imot og selger alt med gjenbruksverdi: bøker, klær, elektronikk, byggevarer, pyntegjenst",
+        "name": "Miljømarkedet",
+        "opening_hours": "Mo-Fr 10:00-16:30; Sa 11:00-15:00; PH,Su off",
+        "operator": "Norges Miljøvernforbunds",
+        "phone": "+47 940 05 571",
+        "second_hand": "yes",
+        "shop": "second_hand",
+        "id": "node/360298302"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          5.3182887,
+          60.3855342
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "node/3684649521",
+      "properties": {
+        "email": "bergen@nlmgjenbruk.no",
+        "name": "Nlm Gjenbruk Bergen",
+        "opening_hours": "We-Fr 12:00-17:00; Sa 11:00-15:00",
+        "phone": "+4740443470",
+        "shop": "second_hand",
+        "id": "node/3684649521"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          5.454787,
+          60.362588
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "node/3946005930",
+      "properties": {
+        "name": "Vitti",
+        "opening_hours": "Tu-Th 12:00-19:00; Fr-Sa 12:00-18:00",
+        "second_hand": "yes",
+        "shop": "clothes",
+        "id": "node/3946005930"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          5.3216649,
+          60.3926603
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "node/3946005947",
+      "properties": {
+        "clothes": "women;men;workwear;suits;denim",
+        "name": "Episode",
+        "opening_hours": "Mo-Sa 11:00-19:00",
+        "second_hand": "yes",
+        "shop": "clothes",
+        "id": "node/3946005947"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          5.3215392,
+          60.392856
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "node/3946005953",
+      "properties": {
+        "description": "Kjøp og salg av hvitevarer og brunevarer",
+        "name": "Nygårdsgaten Brukthandel",
+        "opening_hours": "Mo-Fr 10:00-19:30; Sa 10:00-17:30; Su off",
+        "shop": "second_hand",
+        "id": "node/3946005953"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          5.3288111,
+          60.3872358
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "node/3964625325",
+      "properties": {
+        "name": "NMS Gjenbruk Bergen",
+        "opening_hours": "Mo-We 10:30-16:30; Th 10:30-17:30; Fr 10:30-16:30; Sa 11:00-15:00",
+        "operator": "Det Norske Misjonsselskap",
+        "second_hand": "yes",
+        "shop": "charity",
+        "website": "https://nms.no/butikk/bergen/",
+        "id": "node/3964625325"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          5.322427,
+          60.399174
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "node/3988480605",
+      "properties": {
+        "check_date:opening_hours": "2023-10-22",
+        "name": "Rimelige Hvitevarer",
+        "opening_hours": "Mo-Fr 10:00-18:00; Sa 10:00-17:00",
+        "second_hand": "yes",
+        "shop": "appliance",
+        "id": "node/3988480605"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          5.3226783,
+          60.4008828
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "node/3988501473",
+      "properties": {
+        "opening_hours": "Mo-We 10:30-17:30; Th 10:30-19:00; Fr 10:30-17:00; Sa 10:30-15:00",
+        "second_hand": "yes",
+        "shop": "comics",
+        "id": "node/3988501473"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          5.3263675,
+          60.3969591
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "node/4086570111",
+      "properties": {
+        "opening_hours": "Th 15:30-17:00; Tu 15:30-17:00",
+        "second_hand": "yes",
+        "shop": "books",
+        "id": "node/4086570111"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          5.3509386,
+          60.3613502
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "node/4099728387",
+      "properties": {
+        "contact:facebook": "https://www.facebook.com/secondlovelove",
+        "email": "lisa@secondlove.no",
+        "name": "Second Love",
+        "opening_hours": "Mo-We 11:00-16:00; Th-Fr 11:00-18:00; Sa 11:00-17:00",
+        "phone": "+47 413 57 743",
+        "second_hand": "yes",
+        "shop": "clothes",
+        "website": "http://www.secondlove.no/",
+        "id": "node/4099728387"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          5.328073,
+          60.393835
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "node/4161392159",
+      "properties": {
+        "addr:city": "Bergen",
+        "addr:housenumber": "14-16",
+        "addr:postcode": "5008",
+        "addr:street": "Lars Hilles gate",
+        "brand": "Fretex",
+        "check_date:opening_hours": "2025-01-29",
+        "clothes": "women;men;children;sports;suits;workwear;fashion;unisex",
+        "contact:facebook": "https://www.facebook.com/profile.php?id=100049104231501",
+        "description": "En bruktbutikk i regi av Frelsesarmeen som selger og tar imot blant annet klær, interiørartikler, bøker, sportsutstyr og leker.",
+        "name": "Fretex Lars Hilles gate",
+        "opening_hours": "Mo-Fr 10:00-18:00; Sa 11:00-17:00",
+        "phone": "+47 55321486",
+        "ref:fretex": "132",
+        "second_hand": "yes",
+        "shop": "charity",
+        "toilets:wheelchair": "no",
+        "website": "https://www.fretex.no/handle/finn-butikk/fretex-lars-hillesgate/",
+        "wheelchair": "yes",
+        "id": "node/4161392159"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          5.330452,
+          60.388668
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "node/4161486173",
+      "properties": {
+        "name": "Mamilla Gjenbruk Bergen",
+        "opening_hours": "Mo-Fr 11:00-17:00; Sa 11:00-15:00",
+        "operator": "Den Norske Israelsmisjon",
+        "second_hand": "only",
+        "shop": "second_hand",
+        "website": "https://www.israelsmisjonen.no/norge/misjonsbutikken/mamilla?fbclid=IwAR2kFPcl8jgaKBqir9MTfFofAlsbbpMhuOx2J2WcLKG_gotKp_7s49aJIm4",
+        "id": "node/4161486173"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          5.3392101,
+          60.3751804
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "node/4161552886",
+      "properties": {
+        "branch": "Klesskapet i bergen",
+        "clothes": "women",
+        "name": "Det Gule Hus",
+        "second_hand": "only",
+        "shop": "clothes",
+        "website": "https://detgulehus.no/locations/bergen-klesskapet",
+        "id": "node/4161552886"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          5.346406,
+          60.3721514
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "node/4162069858",
+      "properties": {
+        "name": "Vintage Sisters",
+        "opening_hours": "Fr 12:00-17:00; Sa 12:00-16:00 || \"by appointment\"",
+        "phone": "+47 9719 7274",
+        "second_hand": "yes",
+        "shop": "clothes",
+        "id": "node/4162069858"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          5.3114323,
+          60.3944318
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "node/4171729440",
+      "properties": {
+        "name": "Bokglede",
+        "opening_hours": "Sa 12:00-16:30",
+        "second_hand": "yes",
+        "shop": "books",
+        "id": "node/4171729440"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          5.3215394,
+          60.3902272
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "node/5139480162",
+      "properties": {
+        "facebook": "https://www.facebook.com/velbevartbruktbutikk/",
+        "name": "Vel Bevart Bruktbutikk",
+        "opening_hours": "We-Fr 11:00-17:00; Sa 11:00-15:00",
+        "phone": "+47 471 76 460",
+        "second_hand": "only",
+        "shop": "charity",
+        "id": "node/5139480162"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          5.3674408,
+          60.3583782
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "node/6206106684",
+      "properties": {
+        "brand": "Fretex",
+        "name": "Fretex Åsane",
+        "phone": "+47 55390720",
+        "ref:fretex": "145",
+        "second_hand": "yes",
+        "shop": "charity",
+        "id": "node/6206106684"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          5.337481,
+          60.4702124
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "node/11012179459",
+      "properties": {
+        "contact:facebook": "https://bir.no/aktuelt/birs-ombruksmarked-hver-tirsdag/",
+        "level": "0",
+        "name": "Nyverdi – BIRs ombruksmarked",
+        "opening_hours": "Tu 14-19",
+        "operator": "BIR AS",
+        "payment:app": "yes",
+        "payment:vipps": "yes",
+        "payment:visa": "yes",
+        "second_hand": "yes",
+        "shop": "second_hand",
+        "id": "node/11012179459"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          5.3467569,
+          60.3794122
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "node/11922337264",
+      "properties": {
+        "contact:instagram": "https://www.instagram.com/oybergen/",
+        "name": "ÔY",
+        "opening_hours": "Mo-Sa 12:00-18:00",
+        "second_hand": "yes",
+        "shop": "clothes",
+        "id": "node/11922337264"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          5.3293386,
+          60.3946372
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "node/12087187846",
+      "properties": {
+        "description": "second hand goods free of charge to take - \"freeshop\" - furniture, books, decorations and more",
+        "name": "Brukthallen Bergen",
+        "opening_hours": "Mo-Fr 15-18",
+        "operator": "BIR",
+        "second_hand": "yes",
+        "shop": "second_hand",
+        "id": "node/12087187846"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          5.3443387,
+          60.3791975
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "node/12184425306",
+      "properties": {
+        "description": "Bergenbruktpc.no er en del av A2G Bjørkhaug, en arbeidsmarkedsbedrift som holder til på Storaneset 12, 5260 Indre Arna. Vi er en arbeidsmakedsbedrift som tilbyr Arbeidsforberedende Trening (AFT), Varig Tilrettelagt Arbeid (VTA), og praksisplasser. Når du",
+        "email": "kontakt@bergenbruktpc.no",
+        "name": "Bergen brukt pc",
+        "opening_hours": "Mo-Fr 09:00-15:00",
+        "operator": "A2G Bjørghaug",
+        "phone": "479 76 151",
+        "second_hand": "yes",
+        "shop": "computer",
+        "website": "https://bergenbruktpc.no/",
+        "id": "node/12184425306"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          5.464245,
+          60.430984
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "node/12212402786",
+      "properties": {
+        "branch": "Fana",
+        "name": "Det Gule Hus",
+        "second_hand": "only",
+        "shop": "clothes",
+        "website": "https://detgulehus.no/locations/fana",
+        "id": "node/12212402786"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          5.3278476,
+          60.2952347
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "node/12212402790",
+      "properties": {
+        "branch": "Fyllingsdalen",
+        "fixme": "Vet ikke nøyaktig lokasjon",
+        "name": "Det Gule Hus",
+        "second_hand": "only",
+        "shop": "clothes",
+        "website": "https://detgulehus.no/locations/fyllingsdalen",
+        "id": "node/12212402790"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          5.2774916,
+          60.3508917
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "node/12236198730",
+      "properties": {
+        "addr:city": "Bergen",
+        "addr:housenumber": "95",
+        "addr:postcode": "5008",
+        "addr:street": "Nygårdsgaten",
+        "clothes": "women;men",
+        "name": "CHAMBR",
+        "opening_hours": "Mo-Fr 11:00-17:00, Sa 11:00-16:00",
+        "payment:cards": "yes",
+        "phone": "702 39 745",
+        "second_hand": "only",
+        "shop": "clothes",
+        "website": "https://www.chambr.no/",
+        "id": "node/12236198730"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          5.331966,
+          60.3847451
+        ]
+      }
+    }
+  ]
 }

--- a/src/overpass/fetch-data.ts
+++ b/src/overpass/fetch-data.ts
@@ -3,24 +3,24 @@ import * as path from "path";
 import osmtogeojson from "osmtogeojson";
 
 export async function getFetchUrl(
-  category: "repair" | "rental" | "second-hand"
+  category: "repair" | "rental" | "second-hand",
 ): Promise<string> {
   let filePath;
 
   if (category === "repair") {
     filePath = path.resolve(
       path.dirname(""),
-      "./src/overpass/queries/repair.overpassql"
+      "./src/overpass/queries/repair.overpassql",
     );
   } else if (category === "rental") {
     filePath = path.resolve(
       path.dirname(""),
-      "./src/overpass/queries/rental.overpassql"
+      "./src/overpass/queries/rental.overpassql",
     );
   } else {
     filePath = path.resolve(
       path.dirname(""),
-      "./src/overpass/queries/second-hand.overpassql"
+      "./src/overpass/queries/second-hand.overpassql",
     );
   }
   const data = await fs.readFile(filePath);
@@ -44,6 +44,6 @@ categories.forEach(async (category) => {
 
   await fs.writeFile(
     path.resolve(path.dirname(""), `./src/overpass/data/${category}.json`),
-    JSON.stringify(geojson, null, 2)
+    JSON.stringify(geojson, null, 2),
   );
 });

--- a/src/overpass/fetch-data.ts
+++ b/src/overpass/fetch-data.ts
@@ -1,23 +1,26 @@
 import * as fs from "fs/promises";
 import * as path from "path";
+import osmtogeojson from "osmtogeojson";
 
-export async function getFetchUrl(category) {
+export async function getFetchUrl(
+  category: "repair" | "rental" | "second-hand"
+): Promise<string> {
   let filePath;
 
   if (category === "repair") {
     filePath = path.resolve(
       path.dirname(""),
-      "./src/overpass/queries/repair.overpassql",
+      "./src/overpass/queries/repair.overpassql"
     );
   } else if (category === "rental") {
     filePath = path.resolve(
       path.dirname(""),
-      "./src/overpass/queries/rental.overpassql",
+      "./src/overpass/queries/rental.overpassql"
     );
   } else {
     filePath = path.resolve(
       path.dirname(""),
-      "./src/overpass/queries/second-hand.overpassql",
+      "./src/overpass/queries/second-hand.overpassql"
     );
   }
   const data = await fs.readFile(filePath);
@@ -29,16 +32,18 @@ export async function getFetchUrl(category) {
   return url.href + "?" + urlFormatted.toString();
 }
 
-const categories = ["rental", "repair", "second-hand"];
+const categories = ["rental", "repair", "second-hand"] as const;
 
 categories.forEach(async (category) => {
   const url = await getFetchUrl(category);
   const response = await fetch(url);
 
-  const output = await response.text();
+  const output = await response.json();
+
+  const geojson = osmtogeojson(output);
 
   await fs.writeFile(
-    path.resolve(path.dirname(""), `./src/overpass/data/${category}.osmjson`),
-    output,
+    path.resolve(path.dirname(""), `./src/overpass/data/${category}.json`),
+    JSON.stringify(geojson, null, 2)
   );
 });


### PR DESCRIPTION
move to typescript, use osmtogeojson in the script itself instead of in the CLI script in package.json

We are no longer storing intermediate files, so we remove those from gitignore.

This lays the groundwork for the possiblity of making our own edits to the features before we save the json files, meaning we can process the data and add our own tags if we want