### PR TITLE
fix: filter out weird opening hour entries, add support for irregular opening hours

### DIFF
--- a/src/components/OpeningHours.css
+++ b/src/components/OpeningHours.css
@@ -5,10 +5,13 @@
 }
 
 .opening-hours-lead {
-  cursor: pointer;
   display: flex;
   flex-direction: column;
   gap: 0.4rem;
+}
+
+.pointer {
+  cursor: pointer;
 }
 
 .opening-hours {

--- a/src/components/OpeningHours.tsx
+++ b/src/components/OpeningHours.tsx
@@ -20,12 +20,12 @@ export const OpeningHours: React.FC<OpeningHoursProps> = ({
   const sundayEvening = endOfWeek(now);
   const intervals = oh
     .getOpenIntervals(mondayMorning, sundayEvening)
-    .filter(([_, __, unknown, comment]) => !comment && !unknown);
+    .filter(([_, __, unknown, comment]) => !unknown && !comment);
   const isOpen = oh.getState();
   const nextChange = oh.getNextChange();
 
   const [showOpeningHours, setShowOpeningHours] = useState(
-    window.innerWidth > 968,
+    window.innerWidth > 968
   );
 
   return (

--- a/src/components/OpeningHours.tsx
+++ b/src/components/OpeningHours.tsx
@@ -1,4 +1,4 @@
-import { endOfWeek, format, startOfWeek } from "date-fns";
+import { endOfWeek, format, isAfter, isBefore, startOfWeek } from "date-fns";
 import opening_hours from "opening_hours";
 import "./OpeningHours.css";
 import { nb } from "date-fns/locale";
@@ -23,9 +23,14 @@ export const OpeningHours: React.FC<OpeningHoursProps> = ({
     .filter(([_, __, unknown, comment]) => !unknown && !comment);
   const isOpen = oh.getState();
   const nextChange = oh.getNextChange();
+  const hasDetailedOpeningHours = intervals.length > 1;
+
+  const nextChangeIsWithinWeek = nextChange
+    ? isAfter(nextChange, mondayMorning) && isBefore(nextChange, sundayEvening)
+    : false;
 
   const [showOpeningHours, setShowOpeningHours] = useState(
-    window.innerWidth > 968
+    window.innerWidth > 968 && hasDetailedOpeningHours
   );
 
   return (
@@ -34,8 +39,16 @@ export const OpeningHours: React.FC<OpeningHoursProps> = ({
         <RxClock size={"1.5rem"} />
         <div className="opening-hours-box">
           <div
-            className="opening-hours-lead"
-            onClick={() => setShowOpeningHours(!showOpeningHours)}
+            className={
+              hasDetailedOpeningHours
+                ? "opening-hours-lead pointer"
+                : "opening-hours-lead"
+            }
+            onClick={
+              hasDetailedOpeningHours
+                ? () => setShowOpeningHours(!showOpeningHours)
+                : undefined
+            }
           >
             <div className="opening-hours">
               {isOpen ? (
@@ -52,14 +65,21 @@ export const OpeningHours: React.FC<OpeningHoursProps> = ({
                   <span style={{ color: "red" }}>Stengt</span>
                   {nextChange && (
                     <span>
-                      , åpner {format(nextChange, "eeee HH:mm", { locale: nb })}
+                      , åpner{" "}
+                      {nextChangeIsWithinWeek
+                        ? format(nextChange, "eeee HH:mm", { locale: nb })
+                        : format(nextChange, "do MMMM", {
+                            locale: nb,
+                          })}
                     </span>
                   )}
                 </div>
               )}
-              <div className="opening-hours-toggle">
-                {showOpeningHours ? "vis mindre" : "vis mer"}
-              </div>
+              {hasDetailedOpeningHours && (
+                <div className="opening-hours-toggle">
+                  {showOpeningHours ? "vis mindre" : "vis mer"}
+                </div>
+              )}
             </div>
             <div className="opening-hours-checked">
               {openingHoursChecked &&

--- a/src/components/OpeningHours.tsx
+++ b/src/components/OpeningHours.tsx
@@ -30,7 +30,7 @@ export const OpeningHours: React.FC<OpeningHoursProps> = ({
     : false;
 
   const [showOpeningHours, setShowOpeningHours] = useState(
-    window.innerWidth > 968 && hasDetailedOpeningHours
+    window.innerWidth > 968 && hasDetailedOpeningHours,
   );
 
   return (

--- a/src/components/OpeningHours.tsx
+++ b/src/components/OpeningHours.tsx
@@ -18,7 +18,9 @@ export const OpeningHours: React.FC<OpeningHoursProps> = ({
   const now = new Date();
   const mondayMorning = startOfWeek(now);
   const sundayEvening = endOfWeek(now);
-  const intervals = oh.getOpenIntervals(mondayMorning, sundayEvening);
+  const intervals = oh
+    .getOpenIntervals(mondayMorning, sundayEvening)
+    .filter(([_, __, unknown, comment]) => !comment && !unknown);
   const isOpen = oh.getState();
   const nextChange = oh.getNextChange();
 


### PR DESCRIPTION
In cases such as `Fr 12:00-17:00; Sa 12:00-16:00 || "by appointment"`, `oh.getOpenIntervals()` returns some entries with a comment such as an entry on friday 17:00-00:00 with the comment "by appointment", implying that the place is open on fridays after 17 by appointment, which doesn't really make that much sense. My solution is to filter out entries with a comment. We also filter out entries with unknown = true, which is apparently possible to see if the opening hours are marked as uncertain/maybe. Let's keep it simple and ignore those (at least until we see a use for it).

We could consider adding support for rendering a general "Etter avtale" opening hours. 

Also adds support for irregular opening hours, such as `May-Sep PH,Mo-Su 10:00-15:00`, which will show up (during oct-april) as "åpner 1. mai". The "vis mer" functionality will not be visible in this case, as the expanded opening hours section only shows the opening hours for the current week. 
