### PR TITLE
feat: add link to web manifest

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width" />
     <link rel="icon" type="image/x-icon" href="/kart/favicon.ico" />
+    <link rel="manifest" href="/kart/manifest.webmanifest" />
     <meta name="generator" content={Astro.generator} />
     <title>Gjenbruksportalen</title>
   </head>


### PR DESCRIPTION
This is needed to tell the browser that we have a PWA