### PR TITLE
feat: add header on the top of the page

### DIFF
--- a/src/components/Filter.css
+++ b/src/components/Filter.css
@@ -1,7 +1,7 @@
 .filter-container {
   position: fixed;
   display: flex;
-  top: 1rem;
+  top: 5rem;
   left: 1rem;
   gap: 0.5rem;
 }

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,0 +1,16 @@
+<div>
+  Gjenbruksportalen
+  <slot />
+</div>
+
+<style>
+  div {
+    display: flex;
+    gap: 1rem;
+    height: 2rem;
+    background-color: #ff7a00;
+    font-size: 2rem;
+    padding: 1rem;
+    color: white;
+  }
+</style>

--- a/src/components/InfoBadge.astro
+++ b/src/components/InfoBadge.astro
@@ -20,12 +20,9 @@ import * as Icon from "@astropub/icons";
 
 <style>
   .info-badge {
-    position: fixed;
     display: flex;
     justify-content: center;
     align-items: center;
-    top: 1rem;
-    right: 1rem;
     background-color: white;
     border-radius: 0.5rem;
     box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
@@ -33,6 +30,7 @@ import * as Icon from "@astropub/icons";
     padding: 0.5rem;
     gap: 0.5rem;
     border: none;
+    margin-left: auto;
   }
 
   .info-badge-text {

--- a/src/components/InfoBadge.astro
+++ b/src/components/InfoBadge.astro
@@ -8,12 +8,11 @@ import * as Icon from "@astropub/icons";
 </button>
 
 <script>
-  import { clearSelectedFeature, showInfoPanel } from "../store/feature";
+  import { toggleAboutPanel } from "../store/feature";
   const badge = document.getElementById("info-badge");
   if (badge) {
     badge.addEventListener("click", () => {
-      clearSelectedFeature();
-      showInfoPanel();
+      toggleAboutPanel();
     });
   }
 </script>

--- a/src/components/Map.css
+++ b/src/components/Map.css
@@ -1,7 +1,5 @@
 .map {
-  height: 100vh;
-  height: 100dvh;
-  width: 100vw;
-  width: 100dvw;
+  height: 100%;
+  width: 100%;
   overflow: hidden;
 }

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -136,7 +136,7 @@ export const Map = () => {
             panMapToShowMarker(
               map,
               feature.geometry.coordinates[0],
-              feature.geometry.coordinates[1]
+              feature.geometry.coordinates[1],
             );
           }
         });

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -9,7 +9,7 @@ import {
 } from "../store/feature";
 import { panMapToShowMarker } from "../utils/pan-map";
 import "maplibre-gl/dist/maplibre-gl.css";
-import { $map, setMap } from "../store/map";
+import { setMap } from "../store/map";
 
 export const Map = () => {
   const mapContainer = useRef(null);
@@ -136,7 +136,7 @@ export const Map = () => {
             panMapToShowMarker(
               map,
               feature.geometry.coordinates[0],
-              feature.geometry.coordinates[1],
+              feature.geometry.coordinates[1]
             );
           }
         });

--- a/src/components/MapContainer.astro
+++ b/src/components/MapContainer.astro
@@ -1,0 +1,14 @@
+<div>
+  <slot />
+</div>
+
+<style>
+  div {
+    height: 100vh;
+    height: 100dvh;
+    width: 100vw;
+    width: 100dvw;
+    display: flex;
+    flex-direction: column;
+  }
+</style>

--- a/src/components/Panel.css
+++ b/src/components/Panel.css
@@ -1,6 +1,6 @@
 .panel {
   position: fixed;
-  top: 0.3rem;
+  top: 4.3rem;
   right: 0.3rem;
   bottom: 0.3rem;
   width: 25%;

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -28,8 +28,6 @@
   html,
   body {
     margin: 0;
-    width: 100%;
-    height: 100%;
     font-family: "Diatype Regular", Arial, Helvetica, sans-serif;
   }
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,11 +4,16 @@ import { Map } from "../components/Map";
 import { Panel } from "../components/Panel";
 import Layout from "../layouts/Layout.astro";
 import InfoBadge from "../components/InfoBadge.astro";
+import Header from "../components/Header.astro";
+import MapContainer from "../components/MapContainer.astro";
 ---
 
 <Layout>
-  <Map client:only="react" />
-  <Panel client:only="react" />
-  <Filter client:only="react" />
-  <InfoBadge />
+  <MapContainer>
+    <Header><InfoBadge /></Header>
+    <Map client:only="react" />
+    <Filter client:only="react" />
+
+    <Panel client:only="react" />
+  </MapContainer>
 </Layout>

--- a/src/store/feature.ts
+++ b/src/store/feature.ts
@@ -59,10 +59,6 @@ export function getSelectedFeature(id: string): Feature | undefined {
   }
 }
 
-export function clearSelectedFeature() {
-  $feature.set(null);
-}
-
 export const $showInfoPanel = atom(false);
 
 export function showInfoPanel() {
@@ -71,4 +67,12 @@ export function showInfoPanel() {
 
 export function hideInfoPanel() {
   $showInfoPanel.set(false);
+}
+
+export function toggleAboutPanel() {
+  if ($showInfoPanel.get() && Boolean($feature.get())) {
+    $feature.set(null);
+  } else {
+    $showInfoPanel.set(!$showInfoPanel.get());
+  }
 }

--- a/src/utils/pan-map.ts
+++ b/src/utils/pan-map.ts
@@ -7,7 +7,7 @@ import type maplibregl from "maplibre-gl";
 export function panMapToShowMarker(
   map: maplibregl.Map,
   markerLng: number,
-  markerLat: number
+  markerLat: number,
 ): void {
   const mapWidth = map.getContainer().clientWidth;
   const mapHeight = map.getContainer().clientHeight;

--- a/src/utils/pan-map.ts
+++ b/src/utils/pan-map.ts
@@ -7,12 +7,12 @@ import type maplibregl from "maplibre-gl";
 export function panMapToShowMarker(
   map: maplibregl.Map,
   markerLng: number,
-  markerLat: number,
+  markerLat: number
 ): void {
   const mapWidth = map.getContainer().clientWidth;
   const mapHeight = map.getContainer().clientHeight;
 
-  const bottomPanelHeight = mapHeight / 2;
+  const bottomPanelHeight = (mapHeight + 80) / 2;
   const sidePanelWidth = mapWidth / 4;
 
   const markerPosition = map.project([markerLng, markerLat]);


### PR DESCRIPTION
This makes the map a bit smaller, so there are various tweaks made to the UI elements with position: fixed that are supposed to overlay the map. We could possibly look into using position: absolute and have those be children of the map?