### PR TITLE
fix: show info panel correctly

### DIFF
--- a/src/store/feature.ts
+++ b/src/store/feature.ts
@@ -73,6 +73,7 @@ export function toggleAboutPanel() {
   if ($showInfoPanel.get() && Boolean($feature.get())) {
     $feature.set(null);
   } else {
+    $feature.set(null);
     $showInfoPanel.set(!$showInfoPanel.get());
   }
 }

--- a/src/store/feature.ts
+++ b/src/store/feature.ts
@@ -66,6 +66,7 @@ export function showInfoPanel() {
 }
 
 export function hideInfoPanel() {
+  $feature.set(null);
   $showInfoPanel.set(false);
 }
 
@@ -73,7 +74,6 @@ export function toggleAboutPanel() {
   if ($showInfoPanel.get() && Boolean($feature.get())) {
     $feature.set(null);
   } else {
-    $feature.set(null);
     $showInfoPanel.set(!$showInfoPanel.get());
   }
 }


### PR DESCRIPTION
I forgot to test the case where you click a feature, close the panel, then click the info button. We should of course clear the currently selected feature when we close the panel.