### PR TITLE
feat: make OSM edit link more discrete

### DIFF
--- a/src/components/Panel.css
+++ b/src/components/Panel.css
@@ -53,6 +53,7 @@
 
 .panel-main-content {
   overflow-y: auto;
+  height: 100%;
   display: flex;
   flex-direction: column;
   gap: 1rem;
@@ -81,12 +82,10 @@
   display: flex;
   flex-direction: column;
   justify-content: flex-end;
-  align-items: center;
   gap: 1rem;
   padding-left: 1.5rem;
   padding-right: 1.5rem;
   padding-bottom: 1.5rem;
-  color: white;
 }
 
 @media screen and (max-width: 968px) {
@@ -114,11 +113,7 @@
 }
 
 .edit-link {
-  margin-top: auto;
-  background-color: #ff7a00;
-  color: white;
-  border-radius: 2rem;
-  padding: 1rem;
+  color: #404654;
 }
 
 .feature-info-flex {

--- a/src/components/Panel.tsx
+++ b/src/components/Panel.tsx
@@ -153,12 +153,12 @@ const FeatureInfo: React.FC<FeatureInfoProps> = ({ feature }) => {
       )}
       <div className="panel-footer">
         <a
-          className="feature-info-flex edit-link"
+          className="edit-link"
           href={makeEditorURL(feature.id)}
           target="_blank"
           rel="noreferrer"
         >
-          Oppdater informasjon <RxArrowRight size={"1.2rem"} />
+          Oppdater informasjon
         </a>
       </div>
     </>

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,7 +12,7 @@ interface Config {
 
 export const config: Config = {
   style:
-    "https://api.maptiler.com/maps/8d052b8a-bcfc-4d5f-8d90-f3af6edc8e13/style.json?key=lbu0ev46TofwHO0aj2Dw",
+    "https://api.maptiler.com/maps/8d052b8a-bcfc-4d5f-8d90-f3af6edc8e13/style.json?key=JzEcmTM9DI9IYqHFODOt",
   maxBounds: [
     [4.44, 60.1094],
     [6.3148, 60.5347],

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,7 +12,7 @@ interface Config {
 
 export const config: Config = {
   style:
-    "https://api.maptiler.com/maps/8d052b8a-bcfc-4d5f-8d90-f3af6edc8e13/style.json?key=JzEcmTM9DI9IYqHFODOt",
+    "https://api.maptiler.com/maps/8d052b8a-bcfc-4d5f-8d90-f3af6edc8e13/style.json?key=lbu0ev46TofwHO0aj2Dw",
   maxBounds: [
     [4.44, 60.1094],
     [6.3148, 60.5347],


### PR DESCRIPTION
It's unnecessary to make this link such a prevalent bright orange CTA since it's only meant to be used by mappers. A simple link on the bottom will do.